### PR TITLE
workaround. fix user counting bug.

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/ycsb/YCSBBenchmark.java
+++ b/src/com/oltpbenchmark/benchmarks/ycsb/YCSBBenchmark.java
@@ -49,7 +49,7 @@ public class YCSBBenchmark extends BenchmarkModule {
 
             Table t = this.catalog.getTable("USERTABLE");
             assert (t != null) : "Invalid table name '" + t + "' " + this.catalog.getTables();
-            String userCount = SQLUtil.getMaxColSQL(t, "ycsb_key");
+            String userCount = SQLUtil.getCountSQL(t, "ycsb_key");
             Statement stmt = metaConn.createStatement();
             ResultSet res = stmt.executeQuery(userCount);
             int init_record_count = 0;


### PR DESCRIPTION
Currently, peloton does not support performing some aggregation operations (e.g., min, max) on primary key columns. We need to fix this bug in Peloton.